### PR TITLE
Edit account: fix race condition (fixes parity-js/shell#106)

### DIFF
--- a/src/modals/EditMeta/store.js
+++ b/src/modals/EditMeta/store.js
@@ -97,11 +97,8 @@ export default class Store {
       meta.passwordHint = this.passwordHint;
     }
 
-    return Promise
-      .all([
-        this._api.parity.setAccountName(this.address, this.name),
-        this._api.parity.setAccountMeta(this.address, Object.assign({}, this.meta, meta))
-      ])
+    return this._api.parity.setAccountName(this.address, this.name)
+      .then(() => this._api.parity.setAccountMeta(this.address, Object.assign({}, this.meta, meta)))
       .then(() => {
         if (vaultStore && this.isAccount && (this.meta.vault !== this.vaultName)) {
           return vaultStore.moveAccount(this.vaultName, this.address);


### PR DESCRIPTION
Previously, both RPC calls were made at the same time and modified the same file. This also fixes the account edition not saving properly (I suspect it would either update the account name or the meta information, whichever was processed last). Closes https://github.com/parity-js/shell/issues/106