### PR TITLE
Fix tokens images URL (use dappsUrl)

### DIFF
--- a/src/redux/providers/imagesReducer.js
+++ b/src/redux/providers/imagesReducer.js
@@ -23,10 +23,10 @@ const initialState = {
   images: {}
 };
 
-export function hashToImageUrl (hashArray) {
+export function hashToImageUrl (hashArray, dappsUrl = '') {
   const hash = hashArray ? bytesToHex(hashArray) : ZERO;
 
-  return hash === ZERO ? null : `/api/content/${hash.substr(2)}`;
+  return hash === ZERO ? null : `${dappsUrl}/api/content/${hash.substr(2)}`;
 }
 
 export default handleActions({

--- a/src/util/tokens/index.js
+++ b/src/util/tokens/index.js
@@ -144,13 +144,15 @@ export function fetchTokensImages (api, tokenReg, tokenIndexes) {
   const calls = requests.map((req) => api.eth.call(req));
 
   return Promise.all(calls)
-    .then((results) => {
-      return results.map((rawImage) => {
-        const image = tokenReg.instance.meta.decodeOutput(rawImage)[0].value;
+    .then((results) =>
+      api._parity.dappsUrl().then(dappsUrl =>
+        results.map((rawImage) => {
+          const image = tokenReg.instance.meta.decodeOutput(rawImage)[0].value;
 
-        return hashToImageUrl(image);
-      });
-    });
+          return hashToImageUrl(image, `http://${dappsUrl}`);
+        })
+      )
+    );
 }
 
 /**


### PR DESCRIPTION
Token images were loaded using relative path. Now that we're serving the wallet from the filesystem (built-in dapp), we need to use absolute paths to load the token images

https://github.com/parity-js/shell/pull/126#issuecomment-393572966